### PR TITLE
update android sdk version to 33

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 32
+    compileSdkVersion 33
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
@@ -44,7 +44,7 @@ android {
     defaultConfig {
         applicationId "com.mutualmobile.praxis_flutter"
         minSdkVersion 19
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -514,7 +514,7 @@ packages:
       name: flutter_local_notifications
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.9.0"
+    version: "9.9.1"
   flutter_local_notifications_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   firebase_in_app_messaging: ^0.6.0+23
   firebase_app_installations: ^0.1.1+6
   google_sign_in: ^5.4.1
-  flutter_local_notifications: ^9.9.0
+  flutter_local_notifications: ^9.9.1
   permission_handler: ^10.0.0
   shimmer: ^2.0.0
   uuid: ^3.0.6


### PR DESCRIPTION
Chores:

upgrade to flutter 3.3
updated all pub dependencies
passed routeInformationProvider to Route builders in platform_app.dart as it is a breaking change introduced in
go_router: ^4.3.0
removed deprecated BlocOverrides.runZoned with Bloc.Observer which is reintroduced in BLoC 8.1

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [x] 🗑️ Chore
