### PR TITLE
fix: Using fluter_web_plugin for path strategy

### DIFF
--- a/lib/bootstrap.dart
+++ b/lib/bootstrap.dart
@@ -6,8 +6,8 @@ import 'package:bloc/bloc.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/widgets.dart';
 import 'package:get_it/get_it.dart';
-import 'package:go_router/go_router.dart';
 import 'package:logging/logging.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 import 'package:praxis_flutter/bloc/app_bloc_observer.dart';
 import 'package:praxis_flutter/firebase_options.dart';
 import 'package:praxis_flutter/infrastructure/notifications/firebase_messaging.dart';
@@ -18,7 +18,7 @@ Future<void> bootstrap(FutureOr<Widget> Function() builder, String env) async {
 
   WidgetsFlutterBinding.ensureInitialized();
 
-  GoRouter.setUrlPathStrategy(UrlPathStrategy.path);
+  usePathUrlStrategy();
 
   HttpOverrides.global = MyHttpOverrides();
 


### PR DESCRIPTION
## Description
As mentioned [here](https://github.com/flutter/flutter/issues/108132) the path strategy setting from the [go router](https://pub.dev/packages/go_router/changelog) was removed hence replacing the same with [flutter_web_plugin](https://api.flutter.dev/flutter/flutter_web_plugins/flutter_web_plugins-library.html)

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
